### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/application.py
+++ b/application.py
@@ -78,9 +78,9 @@ def store_in_dynamo(signup_data):
 
 def publish_to_sns(signup_data):
     try:
-        sns_conn.publish(application.config['NEW_SIGNUP_TOPIC'], json.dumps(signup_data), "New signup: %s" % signup_data['email'])
+        sns_conn.publish(application.config['NEW_SIGNUP_TOPIC'], json.dumps(signup_data), "New signup: {0!s}".format(signup_data['email']))
     except Exception as ex:
-        sys.stderr.write("Error publishing subscription message to SNS: %s" % ex.message)
+        sys.stderr.write("Error publishing subscription message to SNS: {0!s}".format(ex.message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tripliks:eb-py-flask-signup?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tripliks:eb-py-flask-signup?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)